### PR TITLE
Tcp client and server, initialization test succeeded

### DIFF
--- a/tcpClientServer/tests/tst_tcpclientserver.cpp
+++ b/tcpClientServer/tests/tst_tcpclientserver.cpp
@@ -12,6 +12,8 @@ private slots:
     void initTestCase();
     void cleanupTestCase();
     void clientFailedInitTest();
+    void succeededInitTest();
+
 };
 
 tcpClientServer::tcpClientServer()
@@ -40,6 +42,27 @@ void tcpClientServer::clientFailedInitTest() {
     clientProcess.waitForFinished();
     QCOMPARE(clientProcess.exitCode(), QProcess::CrashExit);
 }
+
+void tcpClientServer::succeededInitTest() {
+    QProcess serverProcess;
+    serverProcess.start(QString("../tcp-server"), QStringList());
+    serverProcess.waitForStarted();
+
+    QTest::qSleep(1000);
+
+    QProcess clientProcess;
+    clientProcess.start(QString("../tcp-client"), {"--only-init"});
+    clientProcess.waitForStarted();
+
+    clientProcess.write("quit\n");
+
+    clientProcess.waitForFinished();
+    serverProcess.waitForFinished();
+
+    QCOMPARE(clientProcess.exitCode(), QProcess::NormalExit);
+    QCOMPARE(serverProcess.exitCode(), QProcess::NormalExit);
+}
+
 QTEST_APPLESS_MAIN(tcpClientServer)
 
 #include "tst_tcpclientserver.moc"


### PR DESCRIPTION
si avvia sia client che server, i 2 programmi non devono riportare errori( l'inizializzazione deve avere successo )